### PR TITLE
Add the `stat` command to display stats

### DIFF
--- a/src/main/java/duke/command/StatCommand.java
+++ b/src/main/java/duke/command/StatCommand.java
@@ -1,0 +1,35 @@
+package duke.command;
+
+import java.util.HashMap;
+
+import duke.DukeException;
+import duke.storage.Storage;
+import duke.tasklist.TaskList;
+import duke.ui.Ui;
+
+/**
+ * Represents a command to display statistics.
+ */
+public class StatCommand extends Command {
+
+    /**
+     * Executes the command to display statistics.
+     */
+    @Override
+    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        handleTaskBreakdown(tasks, ui);
+    }
+
+    private void handleTaskBreakdown(TaskList tasks, Ui ui) {
+        HashMap<String, Integer> data = tasks.getTaskBreakdown();
+        ui.showPieChart(data);
+    }
+
+    /**
+     * Returns whether the command is an exit command.
+     * @return Whether the command is an exit command.
+     */
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -11,6 +11,7 @@ import duke.command.EventCommand;
 import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
+import duke.command.StatCommand;
 import duke.command.TodoCommand;
 import duke.command.UnmarkCommand;
 
@@ -27,6 +28,7 @@ public class Parser {
     private static final String DELETE_COMMAND = "delete";
     private static final String FIND_COMMAND = "find";
     private static final String BYE_COMMAND = "bye";
+    private static final String STAT_COMMAND = "stat";
 
     /**
      * Parses the user input and returns the corresponding command.
@@ -56,6 +58,8 @@ public class Parser {
             return new ByeCommand();
         case FIND_COMMAND:
             return new FindCommand(commandParts);
+        case STAT_COMMAND:
+            return new StatCommand();
         default:
             throw new DukeException("I'm sorry, but I don't know what that means :-(");
         }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -78,4 +78,13 @@ public abstract class Task {
     public boolean isDone() {
         return this.isDone;
     }
+
+    /**
+     * Returns whether the task is of the same type as the given task.
+     * @param task The task to compare with.
+     * @return Whether the task is of the same type as the given task.
+     */
+    public boolean isSameTaskType(Task task) {
+        return this.getType().equals(task.getType());
+    }
 }

--- a/src/main/java/duke/tasklist/TaskList.java
+++ b/src/main/java/duke/tasklist/TaskList.java
@@ -1,6 +1,7 @@
 package duke.tasklist;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -90,5 +91,18 @@ public class TaskList {
      */
     public List<Task> getTasks() {
         return tasks;
+    }
+
+    /**
+     * Retrieves the breakdown of tasks by type.
+     * @return The breakdown of tasks by type.
+     */
+    public HashMap<String, Integer> getTaskBreakdown() {
+        HashMap<String, Integer> taskCount = new HashMap<>();
+        for (Task task : tasks) {
+            String taskType = task.getType();
+            taskCount.put(taskType, taskCount.getOrDefault(taskType, 0) + 1);
+        }
+        return taskCount;
     }
 }

--- a/src/main/java/duke/ui/Ui.java
+++ b/src/main/java/duke/ui/Ui.java
@@ -1,6 +1,8 @@
 package duke.ui;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import duke.DukeException;
@@ -8,6 +10,7 @@ import duke.task.Task;
 import duke.tasklist.TaskList;
 import javafx.application.Application;
 import javafx.scene.Scene;
+import javafx.scene.chart.PieChart;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
@@ -82,23 +85,27 @@ public class Ui extends Application {
 
         //Step 2. Formatting the window to look as expected
         stage.setTitle("Fluffy");
-        stage.setResizable(false);
+        stage.setResizable(true);
         stage.setMinHeight(600.0);
         stage.setMinWidth(400.0);
 
-        mainLayout.setPrefSize(400.0, 600.0);
+        mainLayout.prefWidthProperty().bind(scene.widthProperty());
+        mainLayout.prefHeightProperty().bind(scene.heightProperty());
 
-        scrollPane.setPrefSize(385, 535);
+        scrollPane.prefWidthProperty().bind(mainLayout.widthProperty());
+        scrollPane.prefHeightProperty().bind(mainLayout.heightProperty().subtract(35));
+
         scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
 
         scrollPane.setVvalue(1.0);
         scrollPane.setFitToWidth(true);
+        scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
 
-        //You will need to import `javafx.scene.layout.Region` for this.
+        // You will need to import `javafx.scene.layout.Region` for this.
         dialogContainer.setPrefHeight(Region.USE_COMPUTED_SIZE);
 
-        userInput.setPrefWidth(325.0);
+        userInput.prefWidthProperty().bind(mainLayout.widthProperty().subtract(55));
 
         sendButton.setPrefWidth(55.0);
 
@@ -237,5 +244,20 @@ public class Ui extends Application {
      */
     public void showTaskDeleted(Task task, int newSize) {
         fluffySpeak("Noted. I've removed this task:\n" + task + "\nNow you have " + newSize + " tasks in the list.");
+    }
+
+    /**
+     * Shows a piechart of the tasks.
+     */
+    public void showPieChart(HashMap<String, Integer> data) {
+        StringBuilder sb = new StringBuilder("Here is a pie chart of your tasks:\n");
+        PieChart pieChart = new PieChart();
+        for (Map.Entry<String, Integer> entry : data.entrySet()) {
+            pieChart.getData().add(new PieChart.Data(entry.getKey(), entry.getValue()));
+        }
+        fluffySpeak(sb.toString());
+        dialogContainer.getChildren().addAll(
+            pieChart
+        );
     }
 }


### PR DESCRIPTION
The current iteration of the `stat` command only displays a pie chart of possible tasks broken down into their types. Future iterations may see extensions being added to this.

To use the `stat` command simply type
```
stat
```
in the user input field.

This commit also adds resizing to the app window, and auto scroll.